### PR TITLE
Nissix plugin scope-packages on fullstack-with-experiments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const bootstrap = require('wix-bootstrap-ng');
+const bootstrap = require('@wix/wix-bootstrap-ng');
 
 const rootDir = process.env.SRC_PATH || './dist/src';
 const getPath = filename => path.join(rootDir, filename);

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "husky": "^0.13.4",
     "jsdom-global": "^2.1.0",
     "react-test-renderer": "^15.5.4",
-    "wix-bootstrap-testkit": "latest",
-    "wix-config-emitter": "latest",
-    "wix-petri-testkit": "^0.1.280",
-    "yoshi": "^2.1.2"
+    "@wix/wix-bootstrap-testkit": "latest",
+    "@wix/wix-config-emitter": "latest",
+    "@wix/wix-petri-testkit": "^0.1.280",
+    "@wix/yoshi": "^2.1.2"
   },
   "dependencies": {
     "axios": "^0.15.2",
@@ -35,11 +35,11 @@
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "prop-types": "^15.5.4",
-    "wix-bootstrap-ng": "latest",
-    "wix-experiments-react": "^1.0.7",
-    "wix-express-rendering-model": "latest",
-    "wix-renderer": "latest",
-    "wix-run-mode": "latest"
+    "@wix/wix-bootstrap-ng": "latest",
+    "@wix/wix-experiments-react": "^1.0.7",
+    "@wix/wix-express-rendering-model": "latest",
+    "@wix/wix-renderer": "latest",
+    "@wix/wix-run-mode": "latest"
   },
   "yoshi": {
     "externals": {
@@ -48,7 +48,9 @@
     }
   },
   "babel": {
-    "presets": ["wix"]
+    "presets": [
+      "wix"
+    ]
   },
   "eslintConfig": {
     "extends": "wix/react"

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {withExperiments} from 'wix-experiments-react';
+import {withExperiments} from '@wix/wix-experiments-react';
 
 const App = props => {
   if (props.experiments.enabled('specs.infra.ExampleSpec')) {

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 import 'regenerator-runtime/runtime';
 import React from 'react';
 import {render} from 'react-dom';
-import {ExperimentsProvider} from 'wix-experiments-react';
+import {ExperimentsProvider} from '@wix/wix-experiments-react';
 import App from './App';
 
 const experiments = window.__EXPERIMENTS__;

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 import 'regenerator-runtime/runtime';
-import wixRenderer from 'wix-renderer';
-import wixRunMode from 'wix-run-mode';
-import wixExpressRenderingModel from 'wix-express-rendering-model';
+import wixRenderer from '@wix/wix-renderer';
+import wixRunMode from '@wix/wix-run-mode';
+import wixExpressRenderingModel from '@wix/wix-express-rendering-model';
 
 module.exports = (app, context) => {
   const config = context.config.load('fullstack-with-experiments');

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,6 +1,6 @@
-import testkit from 'wix-bootstrap-testkit';
-import configEmitter from 'wix-config-emitter';
-import petriTestkit from 'wix-petri-testkit';
+import testkit from '@wix/wix-bootstrap-testkit';
+import configEmitter from '@wix/wix-config-emitter';
+import petriTestkit from '@wix/wix-petri-testkit';
 
 export const app = bootstrapServer();
 export const petriServer = petriTestkit.server({port: 3020});

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {expect} from 'chai';
 import {mount} from 'enzyme';
 import App from '../../src/App';
-import {ExperimentsProvider} from 'wix-experiments-react';
+import {ExperimentsProvider} from '@wix/wix-experiments-react';
 
 describe.jsdom('app', () => {
   function render(experiments) {

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.464s



Output Log:
Migrating package "fullstack-with-experiments" in .


## Migration from non scope to @wix/scoped packages
> /tmp/7f596e5d2fd5c463ea5773f224dafd75

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
index.js
wallaby.js
src/client.js
src/server.js
test/environment.js
src/App/index.js
test/unit/app.spec.js
```

